### PR TITLE
【Scala基礎コース04 挑戦】BM 法の実装

### DIFF
--- a/BMSearch.scala
+++ b/BMSearch.scala
@@ -1,5 +1,57 @@
 object BMSearch extends App {
   val text = "カワカドカドカドドワンゴカドカドンゴドワドワンゴドワカワカドンゴドワ".toSeq
-  val pattern = "ドワンゴ".toSeq
-
+  //val pattern = "ドワンゴ".toSeq
+  val pattern = "ワカドンゴドワ".toSeq
+  // スキップテーブル作成
+  val skipTable = pattern.map(s => (s -> (pattern.reverse.indexOf(s)))).toMap
+  println("skipTable: " + skipTable)
+  val matchIndexes = search(text, pattern)
+  
+  /**
+   * テキストから検索ワードと一致した文字列の先頭位置を返す
+   * @param {text: Seq[Char]} 検索対象のテキスト
+   * @param {pattern: Seq[Char]} 検索ワード
+   * @return {matchIndexes: Seq[Int]} 一致したテキストの先頭位置
+   */
+  def search(text: Seq[Char], pattern: Seq[Char]): Seq[Int] = {
+    var matchIndexes: Seq[Int] = Seq()
+    var i = 0
+    
+    while (i < text.length - 1) {
+      val partText = text.slice(i, i + pattern.length)
+      println("partText: " + partText)
+      val patternLastIndex = pattern.length - 1
+      
+      var isMatch = true
+      var j = patternLastIndex
+      var targetChar = '_'
+      var mismatchPosition = 0
+      
+      while (j >= 0 && isMatch) {
+        if (j > partText.length - 1) {
+          isMatch = false
+        } else {
+          targetChar = partText(j)
+          if (targetChar != pattern(j)) {
+            isMatch = false
+            mismatchPosition = (patternLastIndex - j)
+          }
+        }
+        j = j - 1
+      }
+      
+      if (isMatch) {
+        matchIndexes = matchIndexes :+ i
+        println(s"====== ${i} を登録 ======")
+      }
+      var skipCount = skipTable.getOrElse(targetChar, pattern.length) - mismatchPosition
+      if (skipCount <= 0) skipCount = 1
+      println("skipCount: " + skipCount)
+      i = i + skipCount
+    }
+    
+    matchIndexes
+  }
+  
+  println(s"出現場所: ${matchIndexes}")
 }


### PR DESCRIPTION
練習用ですので、マージは不要です。

---

テキストの模範解答のコードでは、検索ワード( pattern )の先頭文字と末尾文字が同じだった場合、プログラムを実行すると、全文字マッチした後に無限ループになってしまいました。


> 例）val pattern = "ワカドンゴドワ".toSeq（4行目）
> 　　↓
> skipTable: Map(ゴ -> 2, ン -> 3, ド -> 1, ワ -> 0, カ -> 5)（6行目）
> 　　↓
> i = 27 のとき、全文字マッチ！
> 　　↓
> targetChar = 'ワ' ← 先頭文字のワ（34行目）
> 　　↓
> スキップテーブルより Map('ワ' -> 0) だから skipCount = 0 （47行目）
> 　　↓
> i = i + skipCount が変化しない（50行目）
> 　　↓
> while (i < text.length - 1) の条件から外れることができない（20行目）
> 　　↓
> 無限ループ

Map('ワ' -> 0) の存在が原因？
以下のように改良
> 48行目
> if (skipCount < 0) skipCount = 1
> 　　↓
> if (skipCount <= 0) skipCount = 1

これで別の問題が起きなければうれしいです